### PR TITLE
fix: show only one category per subcategory

### DIFF
--- a/card-game-client/app/components/ui/admin-card.tsx
+++ b/card-game-client/app/components/ui/admin-card.tsx
@@ -18,6 +18,7 @@ interface QuizCard {
   question: string;
   file?: string;
   options: string[];
+  answer?: string;
 }
 
 const categories: QuizCard[] = [
@@ -33,6 +34,7 @@ const categories: QuizCard[] = [
       "Tom Felton",
       "Matthew Lewis",
     ],
+    answer: "Daniel Radcliffe",
   },
   {
     id: 2,
@@ -46,6 +48,7 @@ const categories: QuizCard[] = [
       "James Cameron",
       "Ridley Scott",
     ],
+    answer: "Christopher Nolan",
   },
   {
     id: 3,
@@ -54,6 +57,7 @@ const categories: QuizCard[] = [
     question: "How many Home Alone movies are there?",
     file: "https://nextjs.org/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fpreview-audible.6063405a.png&w=640&q=75",
     options: ["1", "2", "3", "4"],
+    answer: "2",
   },
   {
     id: 4,
@@ -67,6 +71,7 @@ const categories: QuizCard[] = [
       "John Adams",
       "James Madison",
     ],
+    answer: "George Washington",
   },
 ];
 
@@ -161,6 +166,7 @@ export default function AdminCard(categoryName: AdminCardProps) {
           <GameCard
             title={selectedCard.subCategory}
             question={selectedCard.question}
+            answer={selectedCard.answer}
             category={selectedCard.category}
             options={selectedCard.options}
             onClose={handleCloseModal}

--- a/card-game-client/app/components/ui/game-card.tsx
+++ b/card-game-client/app/components/ui/game-card.tsx
@@ -10,15 +10,18 @@ interface GameCardProps {
   title?: string;
   category?: string;
   question?: string;
+  answer?: string;
   options?: string[];
   image?: React.ReactNode;
   className?: string;
   onClose?: () => void;
-  categoryItems?: {
+  subCategoryItems?: {
     id: number;
+    subCategory: string;
     title: string;
     question: string;
     options: string[];
+    answer?: string;
   }[];
   admin?: boolean;
   createCard?: boolean;
@@ -38,9 +41,10 @@ export default function GameCard({
   className,
   category,
   question,
+  answer,
   options,
   onClose,
-  categoryItems,
+  subCategoryItems,
   admin,
   createCard,
 }: GameCardProps) {
@@ -57,6 +61,7 @@ export default function GameCard({
   const [editedTitle, setEditedTitle] = useState(title || "");
   const [editedQuestion, setEditedQuestion] = useState(question || "");
   const [editedCategory, setEditedCategory] = useState(category || "");
+  const [editedAnswer, setEditedAnswer] = useState(answer || "");
   const [imageUrl, setImageUrl] = useState("");
 
   const handleChange = (checked: boolean) => {
@@ -101,7 +106,7 @@ export default function GameCard({
   };
 
   const handleNextClick = () => {
-    if (currentItemIndex < (categoryItems?.length ?? 0) - 1) {
+    if (currentItemIndex < (subCategoryItems?.length ?? 0) - 1) {
       setCurrentItemIndex(currentItemIndex + 1);
       setSelectedOption(null);
       setTimeLeft(timeLimit);
@@ -116,6 +121,7 @@ export default function GameCard({
       title: editedTitle,
       category: editedCategory,
       question: editedQuestion,
+      answer: editedAnswer,
       options: editedOptions,
       imageUrl,
     });
@@ -133,32 +139,52 @@ export default function GameCard({
     }
   };
 
-  const currentItem = categoryItems?.[currentItemIndex];
+  const currentItem = subCategoryItems?.[currentItemIndex];
 
   return (
     <Card className="w-full lg:w-3/4 h-auto flex-wrap justify-center">
       <div className="flex justify-between items-center mb-4 w-full">
         <div className="text-gray-600">
-          Category:{" "}
-          {createCard || (admin && editing) ? (
-            <Button
-              variant="outline"
-              dropdown
-              dropdownValues={categoryOptions.map((category) => ({
-                label: category,
-                onClick: () => setEditedCategory(category),
-              }))}
-              placeholder={category}
-              className="w-36 border-thin"
-            >
-              <div className="flex items-center justify-between w-full">
-                <span>{category}</span>
-                <ChevronDownIcon className="h-4 w-4" />
-              </div>
-            </Button>
-          ) : (
-            category
-          )}
+          <div>
+            Category:{" "}
+            {createCard || (admin && editing) ? (
+              <Button
+                variant="outline"
+                dropdown
+                dropdownValues={categoryOptions.map((category) => ({
+                  label: category,
+                  onClick: () => setEditedCategory(category),
+                }))}
+                placeholder={category}
+                className="w-36 border-thin"
+              >
+                <div className="flex items-center justify-between w-full">
+                  <span>{category}</span>
+                  <ChevronDownIcon className="h-4 w-4" />
+                </div>
+              </Button>
+            ) : (
+              category
+            )}
+          </div>
+          <div>
+            Subcategory:{" "}
+            {createCard || (admin && editing) ? (
+              <input
+                type="text"
+                placeholder="Subcategory"
+                value={editedTitle}
+                onBlur={handleOptionBlur}
+                onChange={(e) => setEditedTitle(e.target.value)}
+                className="border rounded p-2 w-36 text-center"
+                autoFocus
+              />
+            ) : admin ? (
+              `${title}`
+            ) : (
+              `${currentItem?.subCategory}`
+            )}
+          </div>
         </div>
         <div className="flex flex-row gap-3">
           {!admin && (
@@ -187,15 +213,6 @@ export default function GameCard({
               <div>
                 <input
                   type="text"
-                  placeholder="Subcategory"
-                  value={editedTitle}
-                  onBlur={handleOptionBlur}
-                  onChange={(e) => setEditedTitle(e.target.value)}
-                  className="border rounded p-2 w-full md:w-36 text-center"
-                  autoFocus
-                />
-                <input
-                  type="text"
                   placeholder="Question"
                   value={editedQuestion}
                   onBlur={handleOptionBlur}
@@ -203,11 +220,20 @@ export default function GameCard({
                   className="border rounded p-2 w-full md:w-64 text-center"
                   autoFocus
                 />
+                <input
+                  type="text"
+                  placeholder="Answer"
+                  value={editedAnswer}
+                  onBlur={handleOptionBlur}
+                  onChange={(e) => setEditedAnswer(e.target.value)}
+                  className="border rounded p-2 w-full md:w-36 text-center"
+                  autoFocus
+                />
               </div>
             ) : admin ? (
-              ` ${title}: ${question}`
+              `${question} ${answer}`
             ) : (
-              `${currentItem?.title}: ${currentItem?.question}`
+              `${currentItem?.title}`
             )}
           </h2>
           <Image
@@ -312,7 +338,7 @@ export default function GameCard({
             >
               {admin
                 ? "Save"
-                : currentItemIndex < (categoryItems?.length ?? 0) - 1
+                : currentItemIndex < (subCategoryItems?.length ?? 0) - 1
                 ? "Next"
                 : "Finish"}
             </Button>

--- a/card-game-client/next.config.mjs
+++ b/card-game-client/next.config.mjs
@@ -1,7 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["nextjs.org"],
+    remotePatterns: [
+      {
+        hostname: "*",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
With this pr:
- updates image source from anywhere in `next.config.mjs`
- groups questions into subcategories and only shows grouped questions (before it would show all question cards)
- updates to prop parameters for editing

https://www.loom.com/share/0fe07bbb2dbc4ae887f5b2bbae7da4fd?sid=f4865c62-35a1-44bc-b71c-a20a8123f15c
