### PR TITLE
Video and Audio support for client side rendering

### DIFF
--- a/card-game-client/app/components/ui/admin-card.tsx
+++ b/card-game-client/app/components/ui/admin-card.tsx
@@ -13,7 +13,7 @@ import Image from "next/image";
 import axios from "axios";
 import { useAtom } from "jotai";
 import { initialQuizCardList } from "@/app/atom/atom";
-import { defaultImageUrl } from "@/app/lib/utils";
+import { defaultImageUrl, videoFileExtensions, fileUploadUrl } from "@/app/lib/utils";
 import { ThreeDots } from "react-loader-spinner";
 
 export interface Category {
@@ -167,23 +167,31 @@ export default function AdminCard(categoryName: AdminCardProps) {
                                     {filteredCardData.id}
                                 </TableCell>
                                 <TableCell>
-                                    <Image
-                                        src={
-                                            imageError[filteredCardData.id]
-                                                ? defaultImageUrl
-                                                : "http://ec2-54-176-67-195.us-west-1.compute.amazonaws.com:8080/uploadFiles/" +
-                                                  (filteredCardData.file
-                                                      ?.savedName || "")
-                                        }
-                                        alt={filteredCardData.subCategory || ""}
-                                        width={50}
-                                        height={50}
-                                        onError={() =>
-                                            handleImageError(
-                                                filteredCardData.id,
-                                            )
-                                        }
-                                    />
+                                    {filteredCardData.file?.extension &&
+                                     videoFileExtensions.includes(filteredCardData.file.extension) ? (
+                                        <video
+                                            src={fileUploadUrl + filteredCardData.file.savedName}
+                                            controls={false}
+                                            width={50}
+                                            height={50}
+                                        />
+                                    ) : (
+                                        <Image
+                                            src={
+                                                imageError[filteredCardData.id]
+                                                    ? defaultImageUrl
+                                                    : fileUploadUrl + (filteredCardData.file?.savedName || "")
+                                            }
+                                            alt={filteredCardData.subCategory || ""}
+                                            width={50}
+                                            height={50}
+                                            onError={() =>
+                                                handleImageError(
+                                                    filteredCardData.id,
+                                                )
+                                            }
+                                        />
+                                    )}
                                 </TableCell>
                                 <TableCell>
                                     {filteredCardData.category.category}

--- a/card-game-client/app/components/ui/admin-card.tsx
+++ b/card-game-client/app/components/ui/admin-card.tsx
@@ -215,7 +215,7 @@ export default function AdminCard(categoryName: AdminCardProps) {
                         category={selectedCard.category.category}
                         options={selectedCard.answerOption}
                         onClose={handleCloseModal}
-                        image={selectedCard.file?.savedName}
+                        media={selectedCard.file?.savedName}
                         quizCardList={quizCardList}
                         admin
                     />

--- a/card-game-client/app/components/ui/game-card.tsx
+++ b/card-game-client/app/components/ui/game-card.tsx
@@ -291,7 +291,6 @@ export default function GameCard({
                             src={mediaUrl}
                             autoPlay={true}
                             controls={true}
-                            className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
                             onError={() => setMediaUrl(defaultImageUrl)}
                         />
                     ) : (
@@ -308,7 +307,7 @@ export default function GameCard({
                         <div>
                             <input
                                 type="file"
-                                accept="image/*, video/*"
+                                accept="image/*, video/*, audio/*"
                                 onChange={handleImageUpload}
                                 style={{ display: "none" }}
                                 id="imageUploadInput"

--- a/card-game-client/app/components/ui/game-card.tsx
+++ b/card-game-client/app/components/ui/game-card.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import Card from "./card";
-import { cn, defaultImageUrl } from "@/app/lib/utils";
+import { cn, defaultImageUrl, fileUploadUrl } from "@/app/lib/utils";
 import { Button } from "./button";
 import { ChevronDownIcon, CrossCircledIcon } from "@radix-ui/react-icons";
 import Switch from "react-switch";
@@ -16,7 +16,7 @@ interface GameCardProps {
     question?: string;
     answer?: string;
     options?: string[];
-    image?: React.ReactNode;
+    media?: React.ReactNode;
     className?: string;
     onClose?: () => void;
     subCategoryItems?: {
@@ -51,7 +51,7 @@ export default function GameCard({
     onClose,
     subCategoryItems,
     admin,
-    image,
+    media,
     createCard,
 }: GameCardProps) {
     const timeLimit = 5;
@@ -68,10 +68,7 @@ export default function GameCard({
     const [editedQuestion, setEditedQuestion] = useState(question || "");
     const [editedCategory, setEditedCategory] = useState(category || "");
     const [editedAnswer, setEditedAnswer] = useState(answer || "");
-    const [imageUrl, setImageUrl] = useState<string>(
-        "http://ec2-54-176-67-195.us-west-1.compute.amazonaws.com:8080/uploadFiles/" +
-            image,
-    );
+    const [mediaUrl, setMediaUrl] = useState<string>(fileUploadUrl + media);
     const [uploadFile, setUploadFile] = useState<File | null>(null);
 
     const [addedCardList, setAddedCardList] = useAtom(initialQuizCardList);
@@ -159,7 +156,7 @@ export default function GameCard({
         if (file) {
             const reader = new FileReader();
             reader.onloadend = () => {
-                setImageUrl(reader.result as string);
+                setMediaUrl(reader.result as string);
                 setUploadFile(file);
             };
             reader.readAsDataURL(file);
@@ -167,6 +164,13 @@ export default function GameCard({
     };
 
     const currentItem = subCategoryItems?.[currentItemIndex];
+
+    const getFileExtension = (url: string) => { return url.substring(url.lastIndexOf(".") + 1).toLowerCase(); }
+    const imageFileExtensions = ["apng", "png", "avif", "gif", "jpg", "jpeg",
+        "jfif", "pjpeg", "pjp", "svg", "webp",
+    ];
+    const videoFileExtensions = ["mp4", "webm", "m4p", "m4v"];
+    const audioFileExtensions = ["mp3", "ogg", "wav", "m4a", "m4b", "m4p", "oga", "mogg", ];
 
     return (
         <Card className="w-full lg:w-3/4 h-auto flex-wrap justify-center">
@@ -277,14 +281,47 @@ export default function GameCard({
                             `${currentItem?.title}`
                         )}
                     </h2>
-                    <Image
-                        src={imageUrl}
-                        width={200}
-                        height={200}
-                        alt={"Quiz card image"}
-                        className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
-                        onError={() => setImageUrl(defaultImageUrl)}
-                    />
+                    { videoFileExtensions.includes(getFileExtension((mediaUrl))) && (
+                        <video
+                            src={mediaUrl}
+                            controls={true}
+                            autoPlay={true}
+                            width={200}
+                            height={200}
+                            className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
+                            onError={() => setMediaUrl(defaultImageUrl)}
+                        />
+                    )}
+                    { audioFileExtensions.includes(getFileExtension((mediaUrl))) && (
+                        <audio
+                            src={mediaUrl}
+                            autoPlay={true}
+                            controls={true}
+                            className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
+                            onError={() => setMediaUrl(defaultImageUrl)}
+                        />
+                    )}
+                    { imageFileExtensions.includes(getFileExtension(mediaUrl)) && (
+                        <Image
+                            src={mediaUrl}
+                            width={200}
+                            height={200}
+                            alt={"Quiz card image"}
+                            className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
+                            onError={() => setMediaUrl(defaultImageUrl)}
+                        />
+                    )}
+                    {   !videoFileExtensions.includes(getFileExtension((mediaUrl))) &&
+                        !audioFileExtensions.includes(getFileExtension((mediaUrl))) &&
+                        !imageFileExtensions.includes(getFileExtension(mediaUrl)) && (
+                            <Image
+                                src={defaultImageUrl}
+                                width={200}
+                                height={200}
+                                alt={"Quiz card image"}
+                                className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
+                            />
+                    )}
                     {admin && (
                         <div>
                             <input

--- a/card-game-client/app/components/ui/game-card.tsx
+++ b/card-game-client/app/components/ui/game-card.tsx
@@ -1,7 +1,13 @@
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import Card from "./card";
-import { cn, defaultImageUrl, fileUploadUrl, videoFileExtensions, audioFileExtensions } from "@/app/lib/utils";
+import {
+    cn,
+    defaultImageUrl,
+    fileUploadUrl,
+    videoFileExtensions,
+    audioFileExtensions,
+} from "@/app/lib/utils";
 import { Button } from "./button";
 import { ChevronDownIcon, CrossCircledIcon } from "@radix-ui/react-icons";
 import Switch from "react-switch";
@@ -165,7 +171,9 @@ export default function GameCard({
 
     const currentItem = subCategoryItems?.[currentItemIndex];
 
-    const getFileExtension = (url: string) => { return url.substring(url.lastIndexOf(".") + 1).toLowerCase(); }
+    const getFileExtension = (url: string) => {
+        return url.substring(url.lastIndexOf(".") + 1).toLowerCase();
+    };
 
     return (
         <Card className="w-full lg:w-3/4 h-auto flex-wrap justify-center">
@@ -276,7 +284,9 @@ export default function GameCard({
                             `${currentItem?.title}`
                         )}
                     </h2>
-                    { videoFileExtensions.includes(getFileExtension((mediaUrl))) ? (
+                    {videoFileExtensions.includes(
+                        getFileExtension(mediaUrl),
+                    ) ? (
                         <video
                             src={mediaUrl}
                             controls={true}
@@ -286,7 +296,9 @@ export default function GameCard({
                             className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
                             onError={() => setMediaUrl(defaultImageUrl)}
                         />
-                    ) : audioFileExtensions.includes(getFileExtension(mediaUrl)) ? (
+                    ) : audioFileExtensions.includes(
+                          getFileExtension(mediaUrl),
+                      ) ? (
                         <audio
                             src={mediaUrl}
                             autoPlay={true}

--- a/card-game-client/app/components/ui/game-card.tsx
+++ b/card-game-client/app/components/ui/game-card.tsx
@@ -32,6 +32,7 @@ interface GameCardProps {
         question: string;
         options: string[];
         answer?: string;
+        media?: string;
     }[];
     admin?: boolean;
     createCard?: boolean;
@@ -138,6 +139,7 @@ export default function GameCard({
             answer: editedAnswer,
             answerOption: editedOptions.toString(),
             file: uploadFile,
+            media: mediaUrl,
         };
 
         axios({
@@ -170,6 +172,8 @@ export default function GameCard({
     };
 
     const currentItem = subCategoryItems?.[currentItemIndex];
+
+    console.log("me", fileUploadUrl + currentItem?.media);
 
     const getFileExtension = (url: string) => {
         return url.substring(url.lastIndexOf(".") + 1).toLowerCase();
@@ -285,10 +289,10 @@ export default function GameCard({
                         )}
                     </h2>
                     {videoFileExtensions.includes(
-                        getFileExtension(mediaUrl),
+                        getFileExtension(currentItem?.media || ""),
                     ) ? (
                         <video
-                            src={mediaUrl}
+                            src={fileUploadUrl + currentItem?.media}
                             controls={true}
                             autoPlay={true}
                             width={200}
@@ -297,17 +301,17 @@ export default function GameCard({
                             onError={() => setMediaUrl(defaultImageUrl)}
                         />
                     ) : audioFileExtensions.includes(
-                          getFileExtension(mediaUrl),
+                          getFileExtension(currentItem?.media || ""),
                       ) ? (
                         <audio
-                            src={mediaUrl}
+                            src={fileUploadUrl + currentItem?.media}
                             autoPlay={true}
                             controls={true}
                             onError={() => setMediaUrl(defaultImageUrl)}
                         />
                     ) : (
                         <Image
-                            src={mediaUrl}
+                            src={fileUploadUrl + currentItem?.media}
                             width={200}
                             height={200}
                             alt={"Quiz card image"}

--- a/card-game-client/app/components/ui/game-card.tsx
+++ b/card-game-client/app/components/ui/game-card.tsx
@@ -173,8 +173,6 @@ export default function GameCard({
 
     const currentItem = subCategoryItems?.[currentItemIndex];
 
-    console.log("me", fileUploadUrl + currentItem?.media);
-
     const getFileExtension = (url: string) => {
         return url.substring(url.lastIndexOf(".") + 1).toLowerCase();
     };

--- a/card-game-client/app/components/ui/game-card.tsx
+++ b/card-game-client/app/components/ui/game-card.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import Card from "./card";
-import { cn, defaultImageUrl, fileUploadUrl } from "@/app/lib/utils";
+import { cn, defaultImageUrl, fileUploadUrl, videoFileExtensions, audioFileExtensions } from "@/app/lib/utils";
 import { Button } from "./button";
 import { ChevronDownIcon, CrossCircledIcon } from "@radix-ui/react-icons";
 import Switch from "react-switch";
@@ -166,11 +166,6 @@ export default function GameCard({
     const currentItem = subCategoryItems?.[currentItemIndex];
 
     const getFileExtension = (url: string) => { return url.substring(url.lastIndexOf(".") + 1).toLowerCase(); }
-    const imageFileExtensions = ["apng", "png", "avif", "gif", "jpg", "jpeg",
-        "jfif", "pjpeg", "pjp", "svg", "webp",
-    ];
-    const videoFileExtensions = ["mp4", "webm", "m4p", "m4v"];
-    const audioFileExtensions = ["mp3", "ogg", "wav", "m4a", "m4b", "m4p", "oga", "mogg", ];
 
     return (
         <Card className="w-full lg:w-3/4 h-auto flex-wrap justify-center">
@@ -281,7 +276,7 @@ export default function GameCard({
                             `${currentItem?.title}`
                         )}
                     </h2>
-                    { videoFileExtensions.includes(getFileExtension((mediaUrl))) && (
+                    { videoFileExtensions.includes(getFileExtension((mediaUrl))) ? (
                         <video
                             src={mediaUrl}
                             controls={true}
@@ -291,8 +286,7 @@ export default function GameCard({
                             className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
                             onError={() => setMediaUrl(defaultImageUrl)}
                         />
-                    )}
-                    { audioFileExtensions.includes(getFileExtension((mediaUrl))) && (
+                    ) : audioFileExtensions.includes(getFileExtension(mediaUrl)) ? (
                         <audio
                             src={mediaUrl}
                             autoPlay={true}
@@ -300,8 +294,7 @@ export default function GameCard({
                             className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
                             onError={() => setMediaUrl(defaultImageUrl)}
                         />
-                    )}
-                    { imageFileExtensions.includes(getFileExtension(mediaUrl)) && (
+                    ) : (
                         <Image
                             src={mediaUrl}
                             width={200}
@@ -310,17 +303,6 @@ export default function GameCard({
                             className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
                             onError={() => setMediaUrl(defaultImageUrl)}
                         />
-                    )}
-                    {   !videoFileExtensions.includes(getFileExtension((mediaUrl))) &&
-                        !audioFileExtensions.includes(getFileExtension((mediaUrl))) &&
-                        !imageFileExtensions.includes(getFileExtension(mediaUrl)) && (
-                            <Image
-                                src={defaultImageUrl}
-                                width={200}
-                                height={200}
-                                alt={"Quiz card image"}
-                                className={cn(["rounded-lg", "md:w-2/5", "mb-6"])}
-                            />
                     )}
                     {admin && (
                         <div>

--- a/card-game-client/app/context/CardsContent.tsx
+++ b/card-game-client/app/context/CardsContent.tsx
@@ -87,11 +87,13 @@ export const CardsProvider = ({ children }: { children: ReactNode }) => {
         const fetchData = async () => {
             if (!hasFetched.current) {
                 setIsLoading(true);
-                fetchQuizCards();
-                fetchCategories();
+                try {
+                    await Promise.all([fetchQuizCards(), fetchCategories()]);
+                } finally {
+                    setIsLoading(false);
+                    hasFetched.current = true;
+                }
                 console.log("Fetching data...");
-                setIsLoading(false);
-                hasFetched.current = true;
             }
         };
 

--- a/card-game-client/app/dashboard/page.tsx
+++ b/card-game-client/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import Header from "../components/header/header";
 import BentoGrid from "../components/ui/bento-grid";
 import Card from "../components/ui/card";
 import Image from "next/image";
-import { defaultImageUrl } from "@/app/lib/utils";
+import {defaultImageUrl, fileUploadUrl, videoFileExtensions} from "@/app/lib/utils";
 import { Button } from "../components/ui/button";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import GameCard from "../components/ui/game-card";
@@ -144,22 +144,32 @@ export default function Dashboard() {
                                 </span>
                             </h1>
                             <div className="flex justify-center items-center w-full h-40">
-                                <Image
-                                    src={
-                                        imageError[card.category.id]
-                                            ? defaultImageUrl
-                                            : `http://ec2-54-176-67-195.us-west-1.compute.amazonaws.com:8080/uploadFiles/${
-                                                  card.questions[0] || ""
-                                              }`
-                                    }
-                                    alt={`${card.subCategory} image`}
-                                    className="object-cover flex flex-wrap"
-                                    width={230}
-                                    height={230}
-                                    onError={() =>
-                                        handleImageError(card.category.id)
-                                    }
-                                />
+                                {card.questions[0].file?.extension &&
+                                videoFileExtensions.includes(card.questions[0].file.extension) ? (
+                                    <video
+                                        src={fileUploadUrl + card.questions[0].file.savedName}
+                                        controls={false}
+                                        width={230}
+                                        height={230}
+                                    />
+                                ) : (
+                                    <Image
+                                        src={
+                                            imageError[card.category.id]
+                                                ? defaultImageUrl
+                                                : `http://ec2-54-176-67-195.us-west-1.compute.amazonaws.com:8080/uploadFiles/${
+                                                    card.questions[0].file?.savedName || ""
+                                                }`
+                                        }
+                                        alt={`${card.subCategory} image`}
+                                        className="object-cover flex flex-wrap"
+                                        width={230}
+                                        height={230}
+                                        onError={() =>
+                                            handleImageError(card.category.id)
+                                        }
+                                    />
+                                )}
                             </div>
                         </Card>
                     ))}

--- a/card-game-client/app/dashboard/page.tsx
+++ b/card-game-client/app/dashboard/page.tsx
@@ -211,6 +211,7 @@ export default function Dashboard() {
                                 title: q.question,
                                 question: q.question,
                                 options: q.answerOptions,
+                                media: q.file?.savedName,
                             }),
                         )}
                         answer={selectedSubCategory.questions

--- a/card-game-client/app/lib/utils.ts
+++ b/card-game-client/app/lib/utils.ts
@@ -8,3 +8,5 @@ export function cn(...inputs: ClassValue[]) {
 export const defaultImageUrl =
     "http://ec2-54-176-67-195.us-west-1.compute.amazonaws.com:8080/uploadFiles/c188b16a-0ce7-404c-8b2e-34129c8b9931_defaultImage.png";
 
+export const fileUploadUrl =
+    "http://ec2-54-176-67-195.us-west-1.compute.amazonaws.com:8080/uploadFiles/"

--- a/card-game-client/app/lib/utils.ts
+++ b/card-game-client/app/lib/utils.ts
@@ -10,3 +10,9 @@ export const defaultImageUrl =
 
 export const fileUploadUrl =
     "http://ec2-54-176-67-195.us-west-1.compute.amazonaws.com:8080/uploadFiles/"
+
+export const imageFileExtensions = ["apng", "png", "avif", "gif", "jpg", "jpeg",
+    "jfif", "pjpeg", "pjp", "svg", "webp"
+];
+export const videoFileExtensions = ["mp4", "webm", "m4p", "m4v"];
+export const audioFileExtensions = ["mp3", "ogg", "wav", "m4a", "m4b", "m4p", "oga", "mogg", ];


### PR DESCRIPTION
This works through checking the file extension of the file link and using conditional rendering (video tag for videos, and audio tags for audio). Currently the render will first check if the file link is a video, then check if its an audio (in game-card), and if it is neither then it will default to trying to render the file as an image. 

I have also added a file extension collection for images in case we want to do quotes, but this can be deleted if we are not doing quotes, as images is the default path and it seems unnecessary to check for image file extension in that case.

Current Issues:
- The different media when clicking on the card to open the game card modal only renders when on the /manage page, they do not render on /dashboard game card.
- The dashboard is setting the images on the preview cards to defaultImage, even when there is an image associated with the card, the only exception it seems like is the very last card.
- A default image is used for cards with audio clips as that is the default path, we can either choose to use a default "audio file" image to represent a card with an audio clip, or use an all encompassing default image to represent multimedia.